### PR TITLE
fix: add permissions block to pr-validation workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 concurrency:
   group: pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Adds top-level `permissions: contents: read` to the `pr-validation.yml` workflow

Addresses the three CodeQL alerts from #4 — all flagged the same missing permissions block, which left the `GITHUB_TOKEN` with default read-write scope.

## Test plan

- [x] Workflow syntax is valid
- [ ] PR validation workflow runs successfully with restricted permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)