### PR TITLE
fix: pin Playwright version to prevent browser mismatch

### DIFF
--- a/.github/test-fixtures/playwright/package.json
+++ b/.github/test-fixtures/playwright/package.json
@@ -6,6 +6,6 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "^1.48.0"
+    "@playwright/test": "1.59.1"
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG PLAYWRIGHT_VERSION=1.59.1
+
 # =============================================================================
 # Build stage: compile GitHub Actions runner and Docker tools
 # =============================================================================
@@ -45,7 +47,7 @@ RUN export RUNNER_ARCH=${TARGETARCH} \
 # =============================================================================
 FROM buildpack-deps:bookworm AS playwright
 
-ARG PLAYWRIGHT_VERSION=latest
+ARG PLAYWRIGHT_VERSION
 ARG NODE_VERSION=20
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -188,11 +190,12 @@ RUN chmod -R 777 /usr/local/share/ms-playwright
 
 # Install Playwright system dependencies
 # We temporarily install playwright just to run install-deps, then remove it
+ARG PLAYWRIGHT_VERSION
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update -y && \
     apt-get install -y --no-install-recommends nodejs npm && \
-    npx --yes playwright@latest install-deps && \
+    npx --yes playwright@${PLAYWRIGHT_VERSION} install-deps && \
     apt-get remove -y nodejs npm && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Pin Playwright to `1.59.1` across the Dockerfile and test fixture to prevent version drift between pre-installed browsers and test runtime
- Share the version via a global Docker `ARG` so the `playwright` build stage and `main` stage `install-deps` both use the same version
- Use exact version (`1.59.1`) instead of range (`^1.48.0`) in the test fixture `package.json`

## Test plan
- [ ] CI builds the Docker image and Playwright browser tests pass (chromium, firefox, webkit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)