### PR TITLE
ci: enforce conventional commit PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   pull-requests: read
+  statuses: write
 
 jobs:
   conventional-title:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,36 @@
+---
+name: Validate PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-title:
+    name: Conventional PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}" must start with a lowercase letter.
+          wip: true


### PR DESCRIPTION
## Summary

- Adds a `Validate PR Title` workflow using `amannn/action-semantic-pull-request@v6`
- Enforces conventional commit prefixes (`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`) on PR titles
- Subject must start with a lowercase letter
- Allows `WIP:` titles for drafts
- Prevents the issue that hit PR #14: squash-merged with title `Extend with buildah and crane`, no conventional prefix, release-please saw nothing releasable, the 1.9.0 bump didn't happen until I backfilled it manually

## Test plan

- [ ] This PR's own title is conventional and the new check passes on it
- [ ] Once merged, the next PR enforcing this rule blocks any non-conventional title

🤖 Generated with [Claude Code](https://claude.com/claude-code)