### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,16 +43,16 @@ jobs:
         language: [actions]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -25,7 +25,7 @@ jobs:
           echo "tag=$SAFE" >> "$GITHUB_OUTPUT"
 
       - name: Delete PR image from GHCR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const tag = '${{ steps.tag.outputs.tag }}';

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: test -f Dockerfile
       - run: test -f version.txt
 
@@ -43,7 +43,7 @@ jobs:
           docker-images: false
           swap-storage: true
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload image artifact (fork PR)
         if: steps.fork.outputs.is_fork == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pr-image
           path: /tmp/pr-image.tar
@@ -116,7 +116,7 @@ jobs:
 
       - name: Comment image reference on PR
         if: steps.fork.outputs.is_fork == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const tag = '${{ steps.tag.outputs.tag }}';
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to GitHub Container Registry
         if: needs.build.outputs.is_fork == 'false'
@@ -188,7 +188,7 @@ jobs:
 
       - name: Download PR image artifact (fork PR)
         if: needs.build.outputs.is_fork == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: pr-image
           path: /tmp
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to GitHub Container Registry
         if: needs.build.outputs.is_fork == 'false'
@@ -232,7 +232,7 @@ jobs:
 
       - name: Download PR image artifact (fork PR)
         if: needs.build.outputs.is_fork == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: pr-image
           path: /tmp

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: lucasilverentand/free-disk-space@44e06ae212258d5c39e5b5602256acd39a2bf002 # v1.0.0
         with:
           tool-cache: false
           android: true
@@ -45,8 +45,8 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       # Fork PRs run with a read-only GITHUB_TOKEN, so they can't push to
       # GHCR or comment on the PR. Detect that up front and branch behavior.
@@ -64,7 +64,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: steps.fork.outputs.is_fork == 'false'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -82,7 +82,7 @@ jobs:
 
       - name: Build and push image (same-repo PR)
         if: steps.fork.outputs.is_fork == 'false'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true
@@ -94,7 +94,7 @@ jobs:
 
       - name: Build image to tar (fork PR)
         if: steps.fork.outputs.is_fork == 'true'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: false
@@ -174,7 +174,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: needs.build.outputs.is_fork == 'false'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -218,7 +218,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: needs.build.outputs.is_fork == 'false'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       packages: write
     steps:
       - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
+        uses: lucasilverentand/free-disk-space@44e06ae212258d5c39e5b5602256acd39a2bf002 # v1.0.0
         with:
           tool-cache: false
           android: true
@@ -34,13 +34,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/seventwo-studio/runner
           tags: |
@@ -61,7 +61,7 @@ jobs:
             type=sha
 
       - name: Build and Push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -123,7 +123,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
@@ -82,7 +82,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -120,7 +120,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release Please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           # Use a fine-grained PAT (contents:write, pull_requests:write) so
           # release-please's PRs trigger CI. Workflows started by GITHUB_TOKEN


### PR DESCRIPTION
## Summary

- Pin every third-party action reference (`docker/*`, `googleapis/release-please-action`, free-disk-space) to a commit SHA with a version comment.
- Swap `jlumbroso/free-disk-space@main` for the new `lucasilverentand/free-disk-space@v1.0.0` (drop-in, same input surface).

## Why

The repo has `sha_pinning_required: true` on Actions, but the workflows reference third-party actions by tag/branch. Every workflow run since late April has hit `startup_failure` in 0s because of this — including scheduled `main` builds and PR checks. That's why PR #27 was stuck (no checks ever reported).

This unblocks CI.

## Test plan

- [ ] PR triggers `Validate Structure`, `Build & Push Image`, `Test Toolchain`, `Test Playwright`, `Analyze (actions)`, `CodeQL` and they actually run (instead of startup_failure).
- [ ] Build & Push Image succeeds — verifies the swap to `lucasilverentand/free-disk-space` works.
- [ ] Next scheduled `Publish Docker Image` and `CodeQL` runs on `main` succeed.