### PR TITLE
chore(renovate): disable lockFileMaintenance

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,4 +3,7 @@
   // Inherit the org-wide Renovate preset. Add per-repo overrides below
   // only if this repo needs to deviate from the shared defaults.
   extends: ["local>seventwo-studio/.github"],
+  // No JS lockfiles in this repo — the test fixtures only ship package.json.
+  // Disable lockFileMaintenance so it stops sitting on the dashboard.
+  lockFileMaintenance: { enabled: false },
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>seventwo-studio/.github"]
+  "extends": ["local>seventwo-studio/.github"],
+  "lockFileMaintenance": { "enabled": false }
 }


### PR DESCRIPTION
## Summary

Adds `lockFileMaintenance: { enabled: false }` to the local Renovate config so the dependency dashboard stops accumulating phantom lock-file-maintenance entries. There are no JS lockfiles in this repo — the test fixtures only ship `package.json` — so the org preset's weekly job has nothing to do.

Touches both `renovate.json` and `.github/renovate.json5` since both currently exist (cleanup of the redundant config is tracked separately in #41).

## Test plan

- [ ] CI passes (lint/build).
- [ ] After merge, the next Renovate run removes the lock-file-maintenance entry from the dependency dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)