### PR TITLE
chore(renovate): remove redundant root renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>seventwo-studio/.github"],
-  "lockFileMaintenance": { "enabled": false }
-}


### PR DESCRIPTION
## Summary
- Deletes the root `renovate.json`, leaving `.github/renovate.json5` as the sole Renovate config.
- Both files extended the same org preset with identical `lockFileMaintenance` override; keeping the JSON5 file preserves the inline comments.

Closes #41

## Test plan
- [ ] Next Renovate run shows a single `renovate-config (1)` entry on the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)